### PR TITLE
Adds parsing the player location from the most recent load or jump

### DIFF
--- a/RatTracker-WPF/RatTracker-WPF/CmdrJournalParser.cs
+++ b/RatTracker-WPF/RatTracker-WPF/CmdrJournalParser.cs
@@ -140,6 +140,7 @@ namespace RatTracker_WPF
     private static readonly ILog Logger = LogManager.GetLogger(Assembly.GetCallingAssembly().GetName().Name);
     private int _lineOffset;
     private LocationLog lastlocation = null;
+    private FsdJumpLog lastjump = null; //I'm certain there's a far far better way to do this, I just can't think of how.
 
     public bool IsListening => _fileListeningActive;
 
@@ -241,6 +242,10 @@ namespace RatTracker_WPF
         {
           LocationEvent?.Invoke(this, lastlocation);
         }
+        else if(lastjump != null)
+        {
+          FsdJumpEvent?.Invoke(this, lastjump);
+        }
         _newFile = false;
         return;
       }
@@ -306,6 +311,11 @@ namespace RatTracker_WPF
           {
             FsdJumpEvent?.Invoke(this, fsdJumpObj);
           }
+          else
+          {
+            lastlocation = null;
+            lastjump = fsdJumpObj;
+          }
           _currentLogFile.CmdrLogEntries.Add(fsdJumpObj);
           break;
         case "Location":
@@ -317,6 +327,7 @@ namespace RatTracker_WPF
           else
           {
             lastlocation = locationObj; //Used to wait till we've parsed the whole log, and only use the most recent load event for position setting.
+            lastjump = null;
           }
           _currentLogFile.CmdrLogEntries.Add(locationObj);
           break;

--- a/RatTracker-WPF/RatTracker-WPF/CmdrJournalParser.cs
+++ b/RatTracker-WPF/RatTracker-WPF/CmdrJournalParser.cs
@@ -25,6 +25,8 @@ namespace RatTracker_WPF
 
   public delegate void FsdJumpEvent(object sender, FsdJumpLog eventData);
 
+  public delegate void LocationEvent(object sender, LocationLog eventData);
+
   public delegate void FuelScoopEvent(object sender, FuelScoopLog eventData);
 
   public delegate void HullDamageEvent(object sender, HullDamageLog eventData);
@@ -116,6 +118,7 @@ namespace RatTracker_WPF
     public event DiedEvent DiedEvent;
     public event EscapeInterdictionEvent EscapeInterdictionEvent;
     public event FsdJumpEvent FsdJumpEvent;
+    public event LocationEvent LocationEvent;
     public event FuelScoopEvent FuelScoopEvent;
     public event HullDamageEvent HullDamageEvent;
     public event InterdictedEvent InterdictedEvent;
@@ -136,6 +139,7 @@ namespace RatTracker_WPF
     private volatile bool _newFile = true;
     private static readonly ILog Logger = LogManager.GetLogger(Assembly.GetCallingAssembly().GetName().Name);
     private int _lineOffset;
+    private LocationLog lastlocation = null;
 
     public bool IsListening => _fileListeningActive;
 
@@ -233,6 +237,10 @@ namespace RatTracker_WPF
         {
           ReadJObjectString(line, true);
         }
+        if (lastlocation != null)
+        {
+          LocationEvent?.Invoke(this, lastlocation);
+        }
         _newFile = false;
         return;
       }
@@ -300,6 +308,18 @@ namespace RatTracker_WPF
           }
           _currentLogFile.CmdrLogEntries.Add(fsdJumpObj);
           break;
+        case "Location":
+          var locationObj = JsonConvert.DeserializeObject<LocationLog>(jObjectString);
+          if (!suppressEvents)
+          {
+            LocationEvent?.Invoke(this, locationObj);
+          }
+          else
+          {
+            lastlocation = locationObj; //Used to wait till we've parsed the whole log, and only use the most recent load event for position setting.
+          }
+          _currentLogFile.CmdrLogEntries.Add(locationObj);
+          break;
         case "FuelScoop":
           var fuelScoopObj = JsonConvert.DeserializeObject<FuelScoopLog>(jObjectString);
           if (!suppressEvents)
@@ -348,7 +368,7 @@ namespace RatTracker_WPF
           }
           _currentLogFile.CmdrLogEntries.Add(supercruiseEntryObj);
           break;
-        case "SuperCruiseExit":
+        case "SupercruiseExit":
           var superCruiseExitObj = JsonConvert.DeserializeObject<SuperCruiseExitLog>(jObjectString);
           if (!suppressEvents)
           {

--- a/RatTracker-WPF/RatTracker-WPF/MainWindow.xaml
+++ b/RatTracker-WPF/RatTracker-WPF/MainWindow.xaml
@@ -233,10 +233,10 @@
         <Grid HorizontalAlignment="Left" Height="125.839" VerticalAlignment="Top" Width="240"
               Margin="0,0,-8.011,-0.773" Background="{DynamicResource brushTransparent}">
           <Label x:Name="DistanceLabel" Content="Unknown Coordinates" HorizontalAlignment="Left" Height="24"
-                 Margin="10,10,0,0" VerticalAlignment="Top" Width="220" Background="{DynamicResource brushTransparent}"
+                 Margin="10,24,0,0" VerticalAlignment="Top" Width="220" Background="{DynamicResource brushTransparent}"
                  Foreground="{DynamicResource brushEliteOrange}" />
           <Label x:Name="SystemNameLabel" Content="{Binding MyPlayer.CurrentSystem}" HorizontalAlignment="Left"
-                 Height="24" Margin="10,10,0,0" VerticalAlignment="Top" Width="220"
+                 Height="24" Margin="10,0,0,0" VerticalAlignment="Top" Width="220"
                  Background="{DynamicResource brushTransparent}" Foreground="{DynamicResource brushEliteOrange}" />
 
           <ToggleButton Content="Show only PC" IsChecked="{Binding ShowOnlyPCCases}" Height="21"

--- a/RatTracker-WPF/RatTracker-WPF/MainWindow.xaml.cs
+++ b/RatTracker-WPF/RatTracker-WPF/MainWindow.xaml.cs
@@ -364,6 +364,7 @@ namespace RatTracker_WPF
             _cmdrJournalParser.DiedEvent += CmdrJournalParser_DiedEvent;
             _cmdrJournalParser.EscapeInterdictionEvent += _cmdrJournalParser_EscapeInterdictionEvent;
             _cmdrJournalParser.FsdJumpEvent += CmdrJournalParser_FsdJumpEvent;
+            _cmdrJournalParser.LocationEvent += CmdrJournalParser_LocationEvent;
             _cmdrJournalParser.HullDamageEvent += CmdrJournalParser_HullDamageEvent;
             _cmdrJournalParser.InterdictedEvent += CmdrJournalParser_InterdictedEvent;
             _cmdrJournalParser.InterdictionEvent += CmdrJournalParser_InterdictionEvent;
@@ -867,6 +868,11 @@ namespace RatTracker_WPF
     }
 
     private void CmdrJournalParser_FsdJumpEvent(object sender, FsdJumpLog eventData)
+    {
+      TriggerSystemChange(eventData.StarSystem);
+    }
+
+    private void CmdrJournalParser_LocationEvent(object sender, LocationLog eventData)
     {
       TriggerSystemChange(eventData.StarSystem);
     }

--- a/RatTracker-WPF/RatTracker-WPF/Models/CmdrJournal/LocationLog.cs
+++ b/RatTracker-WPF/RatTracker-WPF/Models/CmdrJournal/LocationLog.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace RatTracker_WPF.Models.CmdrJournal
+{
+  [JsonObject]
+  public class LocationLog : ICmdrJournalEntry
+  {
+    /// <summary>
+    ///   Array of doubles representing the position of the star on the galactic plane.
+    /// </summary>
+    /// <remarks>Format: {X, Y, Z}</remarks>
+    [JsonProperty]
+    public double[] StarPos { get; set; }
+
+    /// <summary>
+    ///   System's major faction allegiance.
+    /// </summary>
+    [JsonProperty]
+    public string Allegiance { get; set; }
+
+    /// <summary>
+    ///   Star's body name;
+    /// </summary>
+    [JsonProperty]
+    public string Body { get; set; }
+
+    /// <summary>
+    ///   System's economy type.
+    /// </summary>
+    [JsonProperty]
+    public string Economy { get; set; }
+
+    /// <summary>
+    ///   System's controlling minor faction.
+    /// </summary>
+    [JsonProperty]
+    public string Faction { get; set; }
+
+    /// <summary>
+    ///   System's current economic or political state.
+    /// </summary>
+    [JsonProperty]
+    public string FactionState { get; set; }
+
+    /// <summary>
+    ///   Controlling government's type.
+    /// </summary>
+    [JsonProperty]
+    public string Government { get; set; }
+
+    /// <summary>
+    ///   If player is pledged to a power, the system's controlling power.
+    /// </summary>
+    /// <remarks>Use <see cref="PowersList" /> for consistant single result.</remarks>
+    [JsonProperty]
+    public string Power { get; set; }
+
+    /// <summary>
+    ///   If player is pledged to a power, the system's contesting powers.
+    /// </summary>
+    /// <remarks>Use <see cref="PowersList" /> for consistant single result.</remarks>
+    [JsonProperty]
+    public string[] Powers { get; set; }
+
+    /// <summary>
+    ///   if player is pledged to a power, the system's major powers.
+    /// </summary>
+    [JsonIgnore]
+    public string[] PowersList => Powers ?? new[] {Power};
+
+    /// <summary>
+    ///   Security level of the system.
+    /// </summary>
+    [JsonProperty]
+    public string Security { get; set; }
+
+    /// <summary>
+    ///   Name of the star system.
+    /// </summary>
+    [JsonProperty]
+    public string StarSystem { get; set; }
+
+    /// <summary>
+    ///   Time the event occured.
+    /// </summary>
+    [JsonProperty("timestamp")]
+    public DateTime Timestamp { get; set; }
+
+    /// <summary>
+    ///   Event type name.
+    /// </summary>
+    [JsonProperty("event")]
+    public string Event { get; set; }
+  }
+}

--- a/RatTracker-WPF/RatTracker-WPF/RatTracker-WPF.csproj
+++ b/RatTracker-WPF/RatTracker-WPF/RatTracker-WPF.csproj
@@ -231,6 +231,7 @@
     <Compile Include="Models\App\PlayerInfo.cs" />
     <Compile Include="Models\App\RescueData.cs" />
     <Compile Include="Models\App\SysInfo.cs" />
+    <Compile Include="Models\CmdrJournal\LocationLog.cs" />
     <Compile Include="Models\CmdrJournal\WingAddLog.cs" />
     <Compile Include="Models\CmdrJournal\CmdrJournalFile.cs" />
     <Compile Include="Models\CmdrJournal\CommitCrimeLog.cs" />


### PR DESCRIPTION
Adds parsing the current location given when loading. The players location will be set from either the most recent fsd jump event, or the most recent position event.

Slight tweak to the positioning of the system name in the ui, so it doesn't overlap with the distance to Fuelum.